### PR TITLE
[Refactor] #35 : 서류탭 UI 개선

### DIFF
--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -53,8 +53,8 @@
             variant="secondary"
             size="sm"
             @click="emit('cancel')"
-            >{{ cancelText }}</UiButton
-          >
+            >{{ cancelText }}
+          </UiButton>
           <UiButton
             v-if="showConfirmButton"
             variant="primary"

--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -43,12 +43,20 @@
       </div>
 
       <!-- footer 슬롯이 제공되면 그대로 사용, 아니면 기본 버튼 렌더링 -->
-      <div class="flex justify-end gap-3">
+      <div
+        v-if="showCancelButton || showConfirmButton"
+        class="flex justify-end gap-3"
+      >
         <slot name="footer">
-          <UiButton variant="secondary" size="sm" @click="emit('cancel')">{{
-            cancelText
-          }}</UiButton>
           <UiButton
+            v-if="showCancelButton"
+            variant="secondary"
+            size="sm"
+            @click="emit('cancel')"
+            >{{ cancelText }}</UiButton
+          >
+          <UiButton
+            v-if="showConfirmButton"
             variant="primary"
             size="sm"
             :disabled="confirmDisabled"

--- a/src/components/common/ProgressBar.vue
+++ b/src/components/common/ProgressBar.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="h-2 w-full rounded-full bg-gray-200">
+    <div
+      class="h-2 rounded-full bg-[#FFD400] transition-all"
+      :style="{ width: progress + '%' }"
+    ></div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  progress: {
+    type: Number,
+    required: true,
+    validator: value => value >= 0 && value <= 100,
+  },
+});
+</script>

--- a/src/components/common/Toast.vue
+++ b/src/components/common/Toast.vue
@@ -9,7 +9,7 @@
       aria-live="polite"
     >
       <i :class="iconClass(n.type)" aria-hidden="true"></i>
-      <span class="flex-1">{{ n.message }}</span>
+      <span class="flex-1 whitespace-pre-line">{{ n.message }}</span>
       <button
         class="opacity-80 hover:opacity-100"
         aria-label="닫기"

--- a/src/components/docs/ChecklistModal.vue
+++ b/src/components/docs/ChecklistModal.vue
@@ -127,7 +127,6 @@
 <script setup>
 import { computed, ref } from 'vue';
 import Modal from '@/components/common/Modal.vue';
-import UiButton from '@/components/common/UiButton.vue';
 
 const props = defineProps({
   item: {

--- a/src/components/docs/ChecklistModal.vue
+++ b/src/components/docs/ChecklistModal.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center">
+    <!-- 배경 오버레이 -->
+    <div
+      class="absolute inset-0 bg-black bg-opacity-50"
+      @click="closeModal"
+    ></div>
+
+    <!-- 체크리스트 모달 -->
+    <Modal
+      :show="isOpen && !showUploadModal"
+      title="서류 체크리스트"
+      :show-cancel-button="false"
+      :show-confirm-button="false"
+      @close="closeModal"
+    >
+      <!-- 이 안에 컨텐츠만 표시됨 -->
+      <div class="mb-4 rounded-lg bg-gray-50 px-2 py-3">
+        <h4 class="font-medium text-gray-900">{{ item.name }}</h4>
+        <p class="text-sm text-gray-600">{{ item.institution }}</p>
+      </div>
+
+      <div class="space-y-3">
+        <div
+          v-for="(file, index) in requiredDocuments"
+          :key="index"
+          class="flex items-center justify-between rounded-lg border border-gray-200 p-3"
+        >
+          <div class="flex items-center gap-3">
+            <div class="flex-shrink-0">
+              <svg
+                v-if="isDocumentUploaded(file)"
+                class="h-5 w-5 text-green-600"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <svg
+                v-else
+                class="h-5 w-5 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <span class="text-sm font-medium text-gray-900">{{
+              file.name
+            }}</span>
+          </div>
+
+          <button
+            v-if="!isDocumentUploaded(file)"
+            class="rounded-lg bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600 transition-colors hover:bg-blue-100"
+            @click="openUploadModal(file)"
+          >
+            등록하기
+          </button>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- 서류 추가 모달 -->
+    <Modal
+      :show="showUploadModal"
+      title="서류 추가"
+      :show-cancel-button="true"
+      :show-confirm-button="true"
+      cancel-text="취소"
+      confirm-text="추가"
+      @close="closeUploadModal"
+      @cancel="closeUploadModal"
+      @confirm="addDocument"
+    >
+      <div class="space-y-4">
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >서류명</label
+          >
+          <input
+            v-model="newDoc.name"
+            type="text"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+          />
+        </div>
+
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >발급일</label
+          >
+          <input
+            v-model="newDoc.issueDate"
+            type="date"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+          />
+        </div>
+
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >서류 파일</label
+          >
+          <input
+            type="file"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+            @change="handleFileUpload"
+          />
+        </div>
+      </div>
+    </Modal>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import Modal from '@/components/common/Modal.vue';
+import UiButton from '@/components/common/UiButton.vue';
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+  isOpen: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['close']);
+
+// 서류 추가 모달 상태
+const showUploadModal = ref(false);
+const selectedDocument = ref(null);
+
+// 새로운 서류 데이터
+const newDoc = ref({
+  name: '',
+  issueDate: '',
+  file: null,
+});
+
+// 필요한 서류 목록 (실제로는 item에서 가져오거나 별도로 정의)
+const requiredDocuments = computed(() => [
+  { name: '신분증사본', type: 'image' },
+  { name: '소득증빙서류', type: 'document' },
+  { name: '주소증빙서류', type: 'document' },
+  { name: '사업계획서', type: 'document' },
+  { name: '재무제표', type: 'document' },
+]);
+
+// 서류가 업로드되었는지 확인
+const isDocumentUploaded = file => {
+  // 실제로는 item.files에서 해당 서류가 있는지 확인
+  return (
+    props.item.files?.some(
+      uploadedFile =>
+        uploadedFile.name.includes(file.name) ||
+        uploadedFile.name.includes(file.name.replace('사본', ''))
+    ) || false
+  );
+};
+
+// 모달 닫기
+const closeModal = () => {
+  emit('close');
+};
+
+// 서류 등록 모달 열기
+const openUploadModal = file => {
+  selectedDocument.value = file;
+  newDoc.value.name = file.name;
+  showUploadModal.value = true;
+};
+
+// 서류 등록 모달 닫기
+const closeUploadModal = () => {
+  showUploadModal.value = false;
+  selectedDocument.value = null;
+  newDoc.value = { name: '', issueDate: '', file: null };
+};
+
+// 파일 업로드 처리
+const handleFileUpload = event => {
+  newDoc.value.file = event.target.files[0];
+};
+
+// 서류 추가
+const addDocument = () => {
+  if (newDoc.value.name && newDoc.value.issueDate && newDoc.value.file) {
+    // TODO: 실제 서류 추가 로직 구현
+    console.log('서류 추가:', newDoc.value);
+
+    // 폼 초기화 및 모달 닫기
+    newDoc.value = { name: '', issueDate: '', file: null };
+    showUploadModal.value = false;
+
+    // 체크리스트 모달도 닫기
+    emit('close');
+  }
+};
+</script>

--- a/src/components/docs/DocsHelperPanel.vue
+++ b/src/components/docs/DocsHelperPanel.vue
@@ -10,7 +10,7 @@
             <div v-if="isSelectionMode" class="flex items-center gap-2">
               <button
                 :disabled="selectedDocuments.length === 0"
-                class="inline-flex items-center rounded-lg border border-green-200 bg-green-50 px-3 py-1.5 text-xs font-medium text-green-600 transition-colors hover:border-green-300 hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-50"
+                class="inline-flex items-center rounded-lg border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-600 transition-colors hover:border-blue-300 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
                 @click="openConfirmModal('download')"
               >
                 <i class="fas fa-download mr-1.5"></i>
@@ -85,10 +85,12 @@
                       </svg>
                       <!-- 툴팁 -->
                       <div
-                        class="pointer-events-none fixed bottom-auto left-auto right-auto top-auto z-50 mb-2 whitespace-nowrap rounded-lg bg-gray-800 px-3 py-2 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100"
-                        style="transform: translateY(-100%); margin-top: -8px"
+                        class="pointer-events-none absolute bottom-full left-0 z-50 mb-2 whitespace-nowrap rounded-lg bg-gray-800 px-3 py-2 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100"
                       >
                         서류명을 클릭 시 다운로드 할 수 있습니다
+                        <div
+                          class="absolute left-3 top-full h-0 w-0 transform border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"
+                        ></div>
                       </div>
                     </div>
                   </div>

--- a/src/components/docs/DocsHelperPanel.vue
+++ b/src/components/docs/DocsHelperPanel.vue
@@ -5,7 +5,7 @@
       <div class="rounded-2xl border border-[#e5e7eb] bg-white p-6">
         <div class="mb-4 flex items-center justify-between">
           <h3 class="text-lg font-semibold text-gray-900">
-            <i class="fas fa-file-alt mr-2 text-[#2563EB]"></i>
+            <i class="fas fa-file-alt mr-2 text-gray-400"></i>
             내가 등록한 서류
           </h3>
           <div class="flex items-center gap-2">
@@ -144,6 +144,30 @@
             </thead>
             <tbody>
               <tr
+                v-if="myDocuments.length === 0"
+                class="border-b border-gray-50"
+              >
+                <td
+                  :colspan="isSelectionMode ? 5 : 4"
+                  class="px-2 py-8 text-center"
+                >
+                  <div class="flex flex-col items-center gap-3">
+                    <i class="fas fa-file-alt text-4xl text-gray-300"></i>
+                    <div class="text-gray-500">
+                      <p class="font-medium">등록된 서류가 없습니다</p>
+                      <p class="text-sm">첫 번째 서류를 등록해보세요</p>
+                    </div>
+                    <button
+                      class="inline-flex items-center rounded-lg bg-[#2563EB] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#1d4ed8]"
+                      @click="emit('showUploadModal')"
+                    >
+                      <i class="fas fa-plus mr-2"></i>
+                      서류 추가하기
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr
                 v-for="doc in myDocuments"
                 :key="doc.id"
                 class="border-b border-gray-50"
@@ -210,7 +234,7 @@
         <div class="mb-4 flex items-center justify-between">
           <div class="flex items-center gap-2">
             <h3 class="text-lg font-semibold text-gray-900">
-              <i class="fas fa-star mr-2 text-yellow-500"></i>
+              <i class="fas fa-star mr-2 text-gray-400"></i>
               즐겨찾기 상품에 필요한 서류
             </h3>
             <!-- 툴팁 아이콘 -->
@@ -240,13 +264,25 @@
             </div>
           </div>
           <!-- 즐겨찾기 관리 버튼 -->
-          <button
-            class="inline-flex items-center rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-1.5 text-xs font-medium text-yellow-600 transition-colors hover:border-yellow-300 hover:bg-yellow-100"
-            @click="goToFavorites"
-          >
-            <i class="fas fa-star mr-1.5"></i>
-            즐겨찾기 관리
-          </button>
+          <div class="flex items-center gap-2">
+            <span
+              class="cursor-pointer text-xs text-gray-500 hover:text-yellow-600"
+              @click="showFavoritesModal = true"
+            >
+              즐겨찾기
+              <span class="font-medium text-yellow-600">{{
+                favoriteCount
+              }}</span
+              >개
+            </span>
+            <button
+              class="inline-flex items-center rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-1.5 text-xs font-medium text-yellow-600 transition-colors hover:border-yellow-300 hover:bg-yellow-100"
+              @click="goToFavorites"
+            >
+              <i class="fas fa-star mr-1.5"></i>
+              즐겨찾기 관리
+            </button>
+          </div>
         </div>
         <div class="w-full overflow-hidden">
           <table class="w-full table-fixed">
@@ -260,7 +296,7 @@
                 <th
                   class="w-1/4 px-2 py-3 text-left text-sm font-medium text-gray-600"
                 >
-                  요구 건수
+                  필요한 상품수
                 </th>
                 <th
                   class="w-1/5 px-2 py-3 text-left text-sm font-medium text-gray-600"
@@ -276,6 +312,27 @@
             </thead>
             <tbody>
               <tr
+                v-if="requiredDocuments.length === 0"
+                class="border-b border-gray-50"
+              >
+                <td colspan="4" class="px-2 py-8 text-center">
+                  <div class="flex flex-col items-center gap-3">
+                    <i class="fas fa-star text-4xl text-gray-300"></i>
+                    <div class="text-gray-500">
+                      <p class="font-medium">즐겨찾기한 상품이 없습니다</p>
+                      <p class="text-sm">관심 있는 상품을 찾아보세요</p>
+                    </div>
+                    <button
+                      class="inline-flex items-center rounded-lg bg-yellow-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-yellow-600"
+                      @click="goToScheduleList"
+                    >
+                      <i class="fas fa-search mr-2"></i>
+                      상품 살펴보기
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr
                 v-for="doc in requiredDocuments"
                 :key="doc.id"
                 class="border-b border-gray-50"
@@ -284,10 +341,18 @@
                   {{ doc.name }}
                 </td>
                 <td class="px-2 py-3 text-sm text-gray-600">
-                  {{ doc.count }}건
+                  <button
+                    class="cursor-pointer hover:text-[#2563EB] hover:underline"
+                    @click="
+                      showProductsModal = true;
+                      selectedRequiredDoc = doc;
+                    "
+                  >
+                    {{ doc.count }}개
+                  </button>
                 </td>
                 <td class="px-2 py-3">
-                  <Tag :variant="getOwnedVariant(doc.owned)" size="sm">
+                  <Tag :tone="getOwnedVariant(doc.owned)" size="sm">
                     {{ doc.owned }}
                   </Tag>
                 </td>
@@ -306,90 +371,6 @@
             </tbody>
           </table>
         </div>
-      </div>
-    </div>
-
-    <!-- 서류 추가 모달 -->
-    <div
-      v-if="props.showUploadModal"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
-    >
-      <div class="mx-4 w-full max-w-md rounded-2xl bg-white p-6">
-        <div class="mb-4 flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-gray-900">서류 추가</h3>
-          <button
-            class="text-gray-400 hover:text-gray-600"
-            @click="emit('closeUploadModal')"
-          >
-            <svg
-              class="h-6 w-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              ></path>
-            </svg>
-          </button>
-        </div>
-
-        <form class="space-y-4" @submit.prevent="addDocument">
-          <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700"
-              >서류명</label
-            >
-            <input
-              v-model="newDoc.name"
-              type="text"
-              required
-              class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-            />
-          </div>
-
-          <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700"
-              >발급일</label
-            >
-            <input
-              v-model="newDoc.issueDate"
-              type="date"
-              required
-              class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-            />
-          </div>
-
-          <div>
-            <label class="mb-2 block text-sm font-medium text-gray-700"
-              >서류 파일</label
-            >
-            <input
-              type="file"
-              required
-              class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[#2563EB]"
-              @change="handleFileUpload"
-            />
-          </div>
-
-          <div class="flex gap-3 pt-4">
-            <button
-              type="button"
-              class="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-50"
-              @click="emit('closeUploadModal')"
-            >
-              취소
-            </button>
-            <button
-              type="submit"
-              class="flex-1 rounded-lg bg-[#2563EB] px-4 py-2 text-white transition-colors hover:bg-[#1d4ed8]"
-            >
-              추가
-            </button>
-          </div>
-        </form>
       </div>
     </div>
 
@@ -471,30 +452,163 @@
         >건
       </p>
     </Modal>
+
+    <!-- 상품 리스트 모달 -->
+    <Modal
+      :show="showProductsModal"
+      :title="`${selectedRequiredDoc?.name}이(가) 필요한 상품`"
+      subtitle="해당 서류를 요구하는 상품 목록입니다"
+      :show-cancel-button="false"
+      :show-confirm-button="false"
+      @close="showProductsModal = false"
+    >
+      <div class="space-y-3">
+        <div
+          v-for="product in getProductsForDocument(selectedRequiredDoc?.name)"
+          :key="product.id"
+          class="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 p-3"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="flex h-10 w-10 items-center justify-center rounded-full bg-[#2563EB] text-white"
+            >
+              <i
+                :class="
+                  product.type === '정책' ? 'fas fa-gift' : 'fas fa-building'
+                "
+              ></i>
+            </div>
+            <div>
+              <p class="font-medium text-gray-900">{{ product.name }}</p>
+              <p class="text-sm text-gray-600">
+                {{ product.type }} • {{ product.institution }}
+              </p>
+            </div>
+          </div>
+          <div class="text-right">
+            <p class="text-sm font-medium text-[#2563EB]">
+              {{ product.deadline }}
+            </p>
+            <p class="text-xs text-gray-500">
+              {{ product.completedDocs }}/{{ product.totalDocs }} 서류
+            </p>
+          </div>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- 즐겨찾기 상품 목록 모달 -->
+    <Modal
+      :show="showFavoritesModal"
+      title="즐겨찾기한 상품"
+      subtitle="내가 즐겨찾기한 상품 목록입니다"
+      :show-cancel-button="false"
+      :show-confirm-button="false"
+      @close="showFavoritesModal = false"
+    >
+      <div class="space-y-3">
+        <div
+          v-for="product in docsStore.allItems"
+          :key="product.id"
+          class="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 p-3"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="flex h-10 w-10 items-center justify-center rounded-full bg-[#2563EB] text-white"
+            >
+              <i
+                :class="
+                  product.type === '정책' ? 'fas fa-gift' : 'fas fa-building'
+                "
+              ></i>
+            </div>
+            <div>
+              <p class="font-medium text-gray-900">{{ product.name }}</p>
+              <p class="text-sm text-gray-600">
+                {{ product.type }} • {{ product.institution }}
+              </p>
+            </div>
+          </div>
+          <div class="flex items-center gap-3">
+            <div class="text-right">
+              <p class="text-sm font-medium text-[#2563EB]">
+                {{ product.deadline }}
+              </p>
+              <p class="text-xs text-gray-500">
+                {{ product.completedDocs }}/{{ product.totalDocs }} 서류
+              </p>
+            </div>
+            <button
+              class="text-yellow-500 transition-colors hover:text-red-500"
+              @click="openRemoveFavoriteModal(product)"
+            >
+              <i class="fas fa-star text-lg"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useNotificationStore } from '@/stores/notification';
+import { useDocsStore } from '@/stores/docs';
 import Tag from '@/components/common/Tag.vue';
 import Modal from '@/components/common/Modal.vue';
 
 const router = useRouter();
+const docsStore = useDocsStore();
 
 const props = defineProps({
   showUploadModal: {
     type: Boolean,
     default: false,
   },
+  uploadModalData: {
+    type: Object,
+    default: null,
+  },
 });
 
 const emit = defineEmits(['closeUploadModal', 'addDocument']);
 
+// 체크리스트에서 전달된 데이터가 있을 때 서류명 자동 설정
+watch(
+  () => props.uploadModalData,
+  newData => {
+    if (newData && newData.document) {
+      newDoc.value.name = newData.document.name;
+    }
+  },
+  { immediate: true }
+);
+
+// 서류 추가 모달이 닫힐 때 폼 초기화
+watch(
+  () => props.showUploadModal,
+  isOpen => {
+    if (!isOpen) {
+      newDoc.value = { name: '', issueDate: '', file: null };
+    }
+  }
+);
+
 const notification = useNotificationStore();
 const showGuideModal = ref(false);
 const selectedDoc = ref(null);
+
+// 상품 리스트 모달 상태
+const showProductsModal = ref(false);
+const selectedRequiredDoc = ref(null);
+
+// 즐겨찾기 관련 상태
+const showFavoritesModal = ref(false);
+
+// 즐겨찾기 상품 수 (실제로는 API에서 가져와야 함)
+const favoriteCount = ref(12);
 
 const newDoc = ref({
   name: '',
@@ -539,7 +653,7 @@ const myDocuments = ref([
 
 const requiredDocuments = ref([
   { id: 1, name: '주민등록등본', count: 3, owned: '보유' },
-  { id: 2, name: '소득금액증명원', count: 2, owned: '만료' },
+  { id: 2, name: '소득금액증명원', count: 2, owned: '미보유' },
   { id: 3, name: '재직증명서', count: 1, owned: '미보유' },
   { id: 4, name: '건강보험료 납부확인서', count: 2, owned: '보유' },
 ]);
@@ -713,5 +827,32 @@ const getDocumentGuide = docName => {
 
 const goToFavorites = () => {
   router.push('/schedule/favorites');
+};
+
+const goToScheduleList = () => {
+  router.push('/schedule/list');
+};
+
+const getProductsForDocument = docName => {
+  // 실제 상품 데이터에서 해당 서류를 요구하는 상품들을 필터링
+  // 여기서는 간단히 모든 상품을 반환하지만, 실제로는 서류 요구사항에 따라 필터링해야 함
+  return docsStore.allItems;
+};
+
+const openRemoveFavoriteModal = product => {
+  // 바로 제거하고 토스트 표시
+  removeFromFavorites(product);
+};
+
+const removeFromFavorites = product => {
+  if (product) {
+    // 실제로는 API 호출로 즐겨찾기 제거
+    // 여기서는 간단히 favoriteCount만 감소
+    favoriteCount.value = Math.max(0, favoriteCount.value - 1);
+    notification.show(
+      'success',
+      `'${product.name}'이(가)\n즐겨찾기에서 제거되었습니다.`
+    );
+  }
 };
 </script>

--- a/src/components/docs/DocsHelperPanel.vue
+++ b/src/components/docs/DocsHelperPanel.vue
@@ -4,7 +4,10 @@
       <!-- 좌측: 내가 등록한 서류 -->
       <div class="rounded-2xl border border-[#e5e7eb] bg-white p-6">
         <div class="mb-4 flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-gray-900">내가 등록한 서류</h3>
+          <h3 class="text-lg font-semibold text-gray-900">
+            <i class="fas fa-file-alt mr-2 text-[#2563EB]"></i>
+            내가 등록한 서류
+          </h3>
           <div class="flex items-center gap-2">
             <!-- 선택 모드일 때 일괄 처리 버튼들 -->
             <div v-if="isSelectionMode" class="flex items-center gap-2">
@@ -204,9 +207,47 @@
 
       <!-- 우측: 상품에 필요한 서류 -->
       <div class="rounded-2xl border border-[#e5e7eb] bg-white p-6">
-        <h3 class="mb-4 text-lg font-semibold text-gray-900">
-          상품에 필요한 서류
-        </h3>
+        <div class="mb-4 flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <h3 class="text-lg font-semibold text-gray-900">
+              <i class="fas fa-star mr-2 text-yellow-500"></i>
+              즐겨찾기 상품에 필요한 서류
+            </h3>
+            <!-- 툴팁 아이콘 -->
+            <div class="group relative">
+              <svg
+                class="h-4 w-4 cursor-help text-gray-400 hover:text-gray-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                ></path>
+              </svg>
+              <!-- 툴팁 -->
+              <div
+                class="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 transform whitespace-nowrap rounded-lg bg-gray-800 px-3 py-2 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100"
+              >
+                내가 즐겨찾기한 대출/정책 상품에서 요구하는 서류 목록입니다
+                <div
+                  class="absolute left-1/2 top-full h-0 w-0 -translate-x-1/2 transform border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"
+                ></div>
+              </div>
+            </div>
+          </div>
+          <!-- 즐겨찾기 관리 버튼 -->
+          <button
+            class="inline-flex items-center rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-1.5 text-xs font-medium text-yellow-600 transition-colors hover:border-yellow-300 hover:bg-yellow-100"
+            @click="goToFavorites"
+          >
+            <i class="fas fa-star mr-1.5"></i>
+            즐겨찾기 관리
+          </button>
+        </div>
         <div class="w-full overflow-hidden">
           <table class="w-full table-fixed">
             <thead>
@@ -435,9 +476,12 @@
 
 <script setup>
 import { ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
 import { useNotificationStore } from '@/stores/notification';
 import Tag from '@/components/common/Tag.vue';
 import Modal from '@/components/common/Modal.vue';
+
+const router = useRouter();
 
 const props = defineProps({
   showUploadModal: {
@@ -665,5 +709,9 @@ const getDocumentGuide = docName => {
       '건강보험공단 홈페이지에서 발급 가능합니다. 공동인증서 인증이 필요합니다.',
   };
   return guides[docName] || '해당 서류의 발급 방법을 확인해주세요.';
+};
+
+const goToFavorites = () => {
+  router.push('/schedule/favorites');
 };
 </script>

--- a/src/components/docs/DocsListView.vue
+++ b/src/components/docs/DocsListView.vue
@@ -1,99 +1,140 @@
 <template>
-  <div class="overflow-hidden rounded-2xl border border-[#e5e7eb] bg-white">
-    <div class="overflow-x-auto">
-      <table class="w-full">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              유형
-            </th>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              상품명/기관
-            </th>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              상태
-            </th>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              필요서류
-            </th>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              진행률
-            </th>
-            <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
-              액션
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="item in allItems"
-            :key="item.id"
-            class="border-b border-gray-50 hover:bg-gray-50"
-          >
-            <td class="px-6 py-4">
-              <Tag :variant="item.type === '정책' ? 'blue' : 'green'" size="sm">
-                {{ item.type }}
-              </Tag>
-            </td>
-            <td class="px-6 py-4">
-              <div>
-                <p class="font-medium text-gray-900">{{ item.name }}</p>
-                <p class="text-sm text-gray-600">{{ item.institution }}</p>
-              </div>
-            </td>
-            <td class="px-6 py-4">
-              <span
-                :class="{
-                  'bg-gray-100 text-gray-600': item.status === 'requirements',
-                  'bg-blue-100 text-blue-700': item.status === 'collecting',
-                  'bg-yellow-100 text-yellow-700': item.status === 'preparing',
-                  'bg-green-100 text-green-700': item.status === 'completed',
-                }"
-                class="rounded-full px-2 py-1 text-xs font-medium"
-              >
-                {{ getStatusText(item.status) }}
-              </span>
-            </td>
-            <td class="px-6 py-4 text-sm text-gray-600">
-              {{ item.completedDocs }}/{{ item.totalDocs }}
-            </td>
-            <td class="px-6 py-4">
-              <div class="flex items-center gap-2">
-                <div class="h-2 w-16 rounded-full bg-gray-200">
-                  <div
-                    class="h-2 rounded-full bg-[#FFD400]"
-                    :style="{ width: item.progress + '%' }"
-                  ></div>
+  <div>
+    <!-- 체크리스트 모달 -->
+    <ChecklistModal
+      v-if="showChecklistModal"
+      :item="selectedItem"
+      :is-open="showChecklistModal"
+      @close="closeChecklistModal"
+    />
+
+    <div class="overflow-hidden rounded-2xl border border-[#e5e7eb] bg-white">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                유형
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                상품명/기관
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                상태
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                필요서류
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                진행률
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                신청 마감
+              </th>
+              <th class="px-6 py-4 text-left text-sm font-medium text-gray-600">
+                체크리스트
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="item in allItems"
+              :key="item.id"
+              class="border-b border-gray-50 hover:bg-gray-50"
+            >
+              <td class="px-6 py-4">
+                <Tag
+                  :variant="item.type === '정책' ? 'blue' : 'green'"
+                  size="sm"
+                >
+                  {{ item.type }}
+                </Tag>
+              </td>
+              <td class="px-6 py-4">
+                <div>
+                  <p class="font-medium text-gray-900">{{ item.name }}</p>
+                  <p class="text-sm text-gray-600">{{ item.institution }}</p>
                 </div>
-                <span class="text-sm text-gray-600">{{ item.progress }}%</span>
-              </div>
-            </td>
-            <td class="px-6 py-4">
-              <button
-                :class="{
-                  'bg-gray-100 text-gray-600': item.status === 'requirements',
-                  'bg-blue-100 text-blue-700': item.status === 'collecting',
-                  'bg-yellow-100 text-yellow-700': item.status === 'preparing',
-                  'bg-green-100 text-green-700': item.status === 'completed',
-                }"
-                class="!rounded-button cursor-pointer whitespace-nowrap rounded-lg px-3 py-1 text-xs font-medium"
-              >
-                {{ getActionText(item.status) }}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </td>
+              <td class="px-6 py-4">
+                <span
+                  :class="{
+                    'bg-gray-100 text-gray-600': item.status === 'requirements',
+                    'bg-blue-100 text-blue-700': item.status === 'collecting',
+                    'bg-yellow-100 text-yellow-700':
+                      item.status === 'preparing',
+                    'bg-green-100 text-green-700': item.status === 'completed',
+                  }"
+                  class="rounded-full px-2 py-1 text-xs font-medium"
+                >
+                  {{ getStatusText(item.status) }}
+                </span>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-600">
+                {{ item.completedDocs }}/{{ item.totalDocs }}
+              </td>
+              <td class="px-6 py-4">
+                <div class="flex items-center gap-2">
+                  <div class="w-16">
+                    <ProgressBar :progress="item.progress" />
+                  </div>
+                  <span class="text-sm text-gray-600"
+                    >{{ item.progress }}%</span
+                  >
+                </div>
+              </td>
+              <td class="px-6 py-4">
+                <span
+                  :class="{
+                    'font-semibold text-red-600':
+                      item.deadline.includes('D-') &&
+                      parseInt(item.deadline.replace('D-', '')) <= 7,
+                    'font-semibold text-orange-600':
+                      item.deadline.includes('D-') &&
+                      parseInt(item.deadline.replace('D-', '')) <= 14,
+                    'font-semibold text-blue-600':
+                      item.deadline.includes('D-') &&
+                      parseInt(item.deadline.replace('D-', '')) > 14,
+                    'font-semibold text-green-600': item.deadline === '완료',
+                  }"
+                  class="text-sm font-medium"
+                >
+                  {{ item.deadline }}
+                </span>
+              </td>
+              <td class="px-6 py-4">
+                <button
+                  class="!rounded-button flex cursor-pointer items-center gap-2 whitespace-nowrap rounded-lg bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600"
+                  @click="openChecklistModal(item)"
+                >
+                  <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                    <path
+                      fill-rule="evenodd"
+                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                      clip-rule="evenodd"
+                    ></path>
+                  </svg>
+                  체크리스트
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useDocsStore } from '@/stores/docs';
 import Tag from '@/components/common/Tag.vue';
+import ProgressBar from '@/components/common/ProgressBar.vue';
+import ChecklistModal from './ChecklistModal.vue';
 
 const docsStore = useDocsStore();
+const showChecklistModal = ref(false);
+const selectedItem = ref(null);
 
 const allItems = computed(() => docsStore.filteredItems);
 
@@ -115,5 +156,17 @@ const getActionText = status => {
     completed: '결과보기',
   };
   return actionMap[status] || '확인';
+};
+
+// 체크리스트 모달 열기
+const openChecklistModal = item => {
+  selectedItem.value = item;
+  showChecklistModal.value = true;
+};
+
+// 체크리스트 모달 닫기
+const closeChecklistModal = () => {
+  showChecklistModal.value = false;
+  selectedItem.value = null;
 };
 </script>

--- a/src/views/TestView.vue
+++ b/src/views/TestView.vue
@@ -366,35 +366,6 @@ notificationStore.remove(id);</code></pre>
         </div>
       </div>
 
-      <!-- AppHeader 사용법 가이드 -->
-      <Section title="📚 AppHeader 컴포넌트 사용법" class="mb-6" card>
-        <div class="space-y-4">
-          <div class="rounded-lg bg-gray-50 p-4">
-            <h4 class="mb-2 font-medium text-gray-800">사용 예시:</h4>
-            <pre
-              class="overflow-x-auto rounded border bg-white p-3 text-sm"
-            ><code>&lt;AppHeader
-  :chips="['사업자', '소상공인']"
-  :show-bell="true"
-/&gt;</code></pre>
-          </div>
-          <div class="space-y-2 text-sm">
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700">chips:</span>
-              <span class="text-gray-600">Array - 사용자 정보 태그 목록</span>
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-              <span class="text-gray-500">기본값: []</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700">showBell:</span>
-              <span class="text-gray-600">Boolean - 알림 버튼 표시 여부</span>
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-              <span class="text-gray-500">기본값: true</span>
-            </div>
-          </div>
-        </div>
-      </Section>
-
       <!-- SearchBar 테스트 -->
       <Section title="SearchBar 컴포넌트" class="mb-8">
         <div class="max-w-md">
@@ -404,6 +375,57 @@ notificationStore.remove(id);</code></pre>
             @submit="handleSearch"
           />
           <p class="mt-2 text-sm text-gray-600">검색어: {{ searchText }}</p>
+        </div>
+      </Section>
+
+      <!-- SearchBar 사용법 가이드 -->
+      <Section title="📚 SearchBar 컴포넌트 사용법" class="mb-6" card>
+        <div class="space-y-4">
+          <div class="rounded-lg bg-gray-50 p-4">
+            <h4 class="mb-2 font-medium text-gray-800">사용 예시:</h4>
+            <pre
+              class="overflow-x-auto rounded border bg-white p-3 text-sm"
+            ><code>&lt;SearchBar
+  v-model="searchText"
+  placeholder="검색어를 입력하세요..."
+  @submit="handleSearch"
+/&gt;</code></pre>
+          </div>
+          <div class="space-y-2 text-sm">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">modelValue:</span>
+              <span class="text-gray-600">String - 검색어 (v-model)</span>
+              <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700"
+                >필수</span
+              >
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">placeholder:</span>
+              <span class="text-gray-600">String - 플레이스홀더 텍스트</span>
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+              <span class="text-gray-500">기본값: "검색..."</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">@submit:</span>
+              <span class="text-gray-600">Event - 검색 제출 이벤트</span>
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+              <span class="text-gray-500"
+                >Enter 키 또는 검색 버튼 클릭 시 발생</span
+              >
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <!-- Tag 테스트 -->
+      <Section title="Tag 컴포넌트" class="mb-8">
+        <div class="flex flex-wrap gap-2">
+          <Tag label="사업자" tone="gray" size="sm" />
+          <Tag label="소상공인" tone="blue" size="sm" />
+          <Tag label="대출" tone="green" size="sm" />
+          <Tag label="보조금" tone="yellow" size="sm" />
+          <Tag label="중요" tone="red" size="sm" />
+          <Tag label="작은 태그" tone="blue" size="xs" rounded="full" />
         </div>
       </Section>
 
@@ -455,15 +477,14 @@ notificationStore.remove(id);</code></pre>
         </div>
       </Section>
 
-      <!-- Tag 테스트 -->
-      <Section title="Tag 컴포넌트" class="mb-8">
-        <div class="flex flex-wrap gap-2">
-          <Tag label="사업자" tone="gray" size="sm" />
-          <Tag label="소상공인" tone="blue" size="sm" />
-          <Tag label="대출" tone="green" size="sm" />
-          <Tag label="보조금" tone="yellow" size="sm" />
-          <Tag label="중요" tone="red" size="sm" />
-          <Tag label="작은 태그" tone="blue" size="xs" rounded="full" />
+      <!-- UiButton 테스트 -->
+      <Section title="UiButton 컴포넌트" class="mb-8">
+        <div class="flex flex-wrap gap-4">
+          <UiButton variant="primary" size="lg">Primary Large</UiButton>
+          <UiButton variant="secondary" size="md">Secondary Medium</UiButton>
+          <UiButton variant="ghost" size="sm">Ghost Small</UiButton>
+          <UiButton variant="secondary" block>Block Button</UiButton>
+          <UiButton variant="primary" disabled>Disabled Button</UiButton>
         </div>
       </Section>
 
@@ -515,14 +536,17 @@ notificationStore.remove(id);</code></pre>
         </div>
       </Section>
 
-      <!-- UiButton 테스트 -->
-      <Section title="UiButton 컴포넌트" class="mb-8">
-        <div class="flex flex-wrap gap-4">
-          <UiButton variant="primary" size="lg">Primary Large</UiButton>
-          <UiButton variant="secondary" size="md">Secondary Medium</UiButton>
-          <UiButton variant="ghost" size="sm">Ghost Small</UiButton>
-          <UiButton variant="secondary" block>Block Button</UiButton>
-          <UiButton variant="primary" disabled>Disabled Button</UiButton>
+      <!-- Dropdown 테스트 -->
+      <Section title="Dropdown 컴포넌트" class="mb-8">
+        <div class="max-w-xs">
+          <Dropdown
+            v-model="selectedDropdownValue"
+            :options="dropdownOptions"
+            @update:model-value="handleDropdownSelect"
+          />
+          <p class="mt-2 text-sm text-gray-600">
+            선택된 값: {{ selectedDropdownValue }}
+          </p>
         </div>
       </Section>
 
@@ -564,18 +588,9 @@ notificationStore.remove(id);</code></pre>
         </div>
       </Section>
 
-      <!-- Dropdown 테스트 -->
-      <Section title="Dropdown 컴포넌트" class="mb-8">
-        <div class="max-w-xs">
-          <Dropdown
-            v-model="selectedDropdownValue"
-            :options="dropdownOptions"
-            @update:model-value="handleDropdownSelect"
-          />
-          <p class="mt-2 text-sm text-gray-600">
-            선택된 값: {{ selectedDropdownValue }}
-          </p>
-        </div>
+      <!-- MoreButton 테스트 -->
+      <Section title="MoreButton 컴포넌트" class="mb-8">
+        <MoreButton @click="handleMoreClick">더 많은 내용 보기</MoreButton>
       </Section>
 
       <!-- MoreButton 사용법 가이드 -->
@@ -605,9 +620,38 @@ notificationStore.remove(id);</code></pre>
         </div>
       </Section>
 
-      <!-- MoreButton 테스트 -->
-      <Section title="MoreButton 컴포넌트" class="mb-8">
-        <MoreButton @click="handleMoreClick">더 많은 내용 보기</MoreButton>
+      <!-- CardLg 테스트 -->
+      <Section title="CardLg 컴포넌트" class="mb-8">
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <CardLg
+            title="대출 상품 A"
+            badge="신규"
+            badge-tone="green"
+            :details="[
+              { label: '대출 한도', value: '최대 5천만원' },
+              { label: '이자율', value: '연 3.5%', tone: 'danger' },
+              { label: '상환기간', value: '최대 10년' },
+            ]"
+            action-label="상세보기"
+            :favorited="false"
+            @action="handleCardAction"
+            @update:favorited="handleFavoriteUpdate"
+          />
+          <CardLg
+            title="보조금 지원 B"
+            badge="마감임박"
+            badge-tone="red"
+            :details="[
+              { label: '지원금액', value: '최대 3천만원' },
+              { label: '신청기간', value: '2024.12.31까지' },
+              { label: '지원대상', value: '소상공인' },
+            ]"
+            action-label="신청하기"
+            :favorited="true"
+            @action="handleCardAction"
+            @update:favorited="handleFavoriteUpdate"
+          />
+        </div>
       </Section>
 
       <!-- CardLg 사용법 가이드 -->
@@ -676,36 +720,32 @@ notificationStore.remove(id);</code></pre>
         </div>
       </Section>
 
-      <!-- CardLg 테스트 -->
-      <Section title="CardLg 컴포넌트" class="mb-8">
-        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-          <CardLg
-            title="대출 상품 A"
-            badge="신규"
-            badge-tone="green"
-            :details="[
-              { label: '대출 한도', value: '최대 5천만원' },
-              { label: '이자율', value: '연 3.5%', tone: 'danger' },
-              { label: '상환기간', value: '최대 10년' },
-            ]"
-            action-label="상세보기"
-            :favorited="false"
-            @action="handleCardAction"
-            @update:favorited="handleFavoriteUpdate"
+      <!-- CardSm 테스트 -->
+      <Section title="CardSm 컴포넌트" class="mb-8">
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <CardSm
+            title="상품 1"
+            label="신규"
+            label-tone="green"
+            meta="2024.12.01 등록"
           />
-          <CardLg
-            title="보조금 지원 B"
-            badge="마감임박"
-            badge-tone="red"
-            :details="[
-              { label: '지원금액', value: '최대 3천만원' },
-              { label: '신청기간', value: '2024.12.31까지' },
-              { label: '지원대상', value: '소상공인' },
-            ]"
-            action-label="신청하기"
-            :favorited="true"
-            @action="handleCardAction"
-            @update:favorited="handleFavoriteUpdate"
+          <CardSm
+            title="상품 2"
+            label="인기"
+            label-tone="red"
+            meta="조회수 1,234"
+          />
+          <CardSm
+            title="상품 3"
+            label="추천"
+            label-tone="blue"
+            meta="평점 4.8"
+          />
+          <CardSm
+            title="상품 4"
+            label="특가"
+            label-tone="yellow"
+            meta="할인 20%"
           />
         </div>
       </Section>
@@ -752,111 +792,6 @@ notificationStore.remove(id);</code></pre>
               <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
               <span class="text-gray-500">기본값: ""</span>
             </div>
-          </div>
-        </div>
-      </Section>
-
-      <!-- CardSm 테스트 -->
-      <Section title="CardSm 컴포넌트" class="mb-8">
-        <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-          <CardSm
-            title="상품 1"
-            label="신규"
-            label-tone="green"
-            meta="2024.12.01 등록"
-          />
-          <CardSm
-            title="상품 2"
-            label="인기"
-            label-tone="red"
-            meta="조회수 1,234"
-          />
-          <CardSm
-            title="상품 3"
-            label="추천"
-            label-tone="blue"
-            meta="평점 4.8"
-          />
-          <CardSm
-            title="상품 4"
-            label="특가"
-            label-tone="yellow"
-            meta="할인 20%"
-          />
-        </div>
-      </Section>
-
-      <!-- Modal 사용법 가이드 -->
-      <Section title="📚 Modal 컴포넌트 사용법" class="mb-6" card>
-        <div class="space-y-4">
-          <div class="rounded-lg bg-gray-50 p-4">
-            <h4 class="mb-2 font-medium text-gray-800">기본 사용법:</h4>
-            <pre
-              class="overflow-x-auto rounded border bg-white p-3 text-sm"
-            ><code>&lt;Modal
-  :show="open"
-  title="모달 제목"
-  subtitle="서브타이틀"
-  @close="open = false"
-  @confirm="handleConfirm"
-  @cancel="open = false"
-&gt;
-  내용 영역
-&lt;/Modal&gt;</code></pre>
-          </div>
-
-          <div class="space-y-2 text-sm">
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700">show:</span>
-              <span class="text-gray-600">Boolean - 표시 여부</span>
-              <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700"
-                >필수</span
-              >
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700">title / subtitle:</span>
-              <span class="text-gray-600">String - 제목 / 서브타이틀</span>
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700"
-                >cancelText / confirmText:</span
-              >
-              <span class="text-gray-600">String - 버튼 텍스트</span>
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-              <span class="text-gray-500">기본값: "취소" / "확인"</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700">confirmDisabled:</span>
-              <span class="text-gray-600">Boolean - 확인 비활성화</span>
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-              <span class="text-gray-500">기본값: false</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-700"
-                >showCloseButton / closeOnBackdrop:</span
-              >
-              <span class="text-gray-600"
-                >Boolean - 닫기 버튼 / 배경 클릭 닫기</span
-              >
-              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
-              <span class="text-gray-500">기본값: true / true</span>
-            </div>
-          </div>
-
-          <div class="rounded-lg bg-gray-50 p-4">
-            <h4 class="mb-2 font-medium text-gray-800">
-              커스텀 푸터 (footer 슬롯):
-            </h4>
-            <pre
-              class="overflow-x-auto rounded border bg-white p-3 text-sm"
-            ><code>&lt;Modal :show="open" title="제목" @close="open=false"&gt;
-  내용
-  &lt;template #footer&gt;
-    &lt;UiButton variant="ghost" size="sm" @click="open=false"&gt;닫기&lt;/UiButton&gt;
-    &lt;UiButton variant="primary" size="sm" @click="handleCustomConfirm"&gt;저장&lt;/UiButton&gt;
-  &lt;/template&gt;
-&lt;/Modal&gt;</code></pre>
           </div>
         </div>
       </Section>
@@ -916,7 +851,7 @@ notificationStore.remove(id);</code></pre>
                   <input
                     v-model="customForm.email"
                     type="email"
-                    class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    class="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     placeholder="이메일을 입력하세요"
                   />
                 </div>
@@ -985,6 +920,141 @@ notificationStore.remove(id);</code></pre>
           </div>
         </div>
       </Section>
+
+      <!-- Modal 사용법 가이드 -->
+      <Section title="📚 Modal 컴포넌트 사용법" class="mb-6" card>
+        <div class="space-y-4">
+          <div class="rounded-lg bg-gray-50 p-4">
+            <h4 class="mb-2 font-medium text-gray-800">기본 사용법:</h4>
+            <pre
+              class="overflow-x-auto rounded border bg-white p-3 text-sm"
+            ><code>&lt;Modal
+          :show="open"
+          title="모달 제목"
+          subtitle="서브타이틀"
+          @close="open = false"
+          @confirm="handleConfirm"
+          @cancel="open = false"
+          &gt;
+          내용 영역
+          &lt;/Modal&gt;</code></pre>
+          </div>
+
+          <div class="space-y-2 text-sm">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">show:</span>
+              <span class="text-gray-600">Boolean - 표시 여부</span>
+              <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700"
+                >필수</span
+              >
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">title / subtitle:</span>
+              <span class="text-gray-600">String - 제목 / 서브타이틀</span>
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700"
+                >cancelText / confirmText:</span
+              >
+              <span class="text-gray-600">String - 버튼 텍스트</span>
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+              <span class="text-gray-500">기본값: "취소" / "확인"</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">confirmDisabled:</span>
+              <span class="text-gray-600">Boolean - 확인 비활성화</span>
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+              <span class="text-gray-500">기본값: false</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700"
+                >showCloseButton / closeOnBackdrop:</span
+              >
+              <span class="text-gray-600"
+                >Boolean - 닫기 버튼 / 배경 클릭 닫기</span
+              >
+              <span class="rounded bg-gray-100 px-2 py-1 text-xs">선택</span>
+              <span class="text-gray-500">기본값: true / true</span>
+            </div>
+          </div>
+
+          <div class="rounded-lg bg-gray-50 p-4">
+            <h4 class="mb-2 font-medium text-gray-800">
+              커스텀 푸터 (footer 슬롯):
+            </h4>
+            <pre
+              class="overflow-x-auto rounded border bg-white p-3 text-sm"
+            ><code>&lt;Modal :show="open" title="제목"
+          @close="open=false"&gt;
+          내용
+          &lt;template #footer&gt;
+          &lt;UiButton variant="ghost" size="sm" @click="open=false"&gt;닫기&lt;/UiButton&gt;
+          &lt;UiButton variant="primary" size="sm" @click="handleCustomConfirm"&gt;저장&lt;/UiButton&gt;
+          &lt;/template&gt;
+          &lt;/Modal&gt;</code></pre>
+          </div>
+        </div>
+      </Section>
+
+      <!-- ProgressBar 테스트 -->
+      <Section title="ProgressBar 컴포넌트" class="mb-8">
+        <div class="space-y-4">
+          <div class="flex items-center gap-4">
+            <span class="w-20 text-sm font-medium text-gray-700">0%</span>
+            <div class="flex-1">
+              <ProgressBar :progress="0" />
+            </div>
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="w-20 text-sm font-medium text-gray-700">25%</span>
+            <div class="flex-1">
+              <ProgressBar :progress="25" />
+            </div>
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="w-20 text-sm font-medium text-gray-700">50%</span>
+            <div class="flex-1">
+              <ProgressBar :progress="50" />
+            </div>
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="w-20 text-sm font-medium text-gray-700">75%</span>
+            <div class="flex-1">
+              <ProgressBar :progress="75" />
+            </div>
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="w-20 text-sm font-medium text-gray-700">100%</span>
+            <div class="flex-1">
+              <ProgressBar :progress="100" />
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <!-- ProgressBar 사용법 가이드 -->
+      <Section title="📚 ProgressBar 컴포넌트 사용법" class="mb-6" card>
+        <div class="space-y-4">
+          <div class="rounded-lg bg-gray-50 p-4">
+            <h4 class="mb-2 font-medium text-gray-800">사용 예시:</h4>
+            <pre
+              class="overflow-x-auto rounded border bg-white p-3 text-sm"
+            ><code>&lt;ProgressBar :progress="75" /&gt;</code>
+      </pre>
+          </div>
+          <div class="space-y-2 text-sm">
+            <div class="flex items-center gap-2">
+              <span class="font-medium text-gray-700">progress:</span>
+              <span class="text-gray-600">Number - 진행률 (0-100)</span>
+              <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700"
+                >필수</span
+              >
+              <span class="text-gray-500">0-100 사이의 값만 허용</span>
+            </div>
+          </div>
+        </div>
+      </Section>
     </div>
   </div>
 </template>
@@ -1002,6 +1072,7 @@ import CardLg from '@/components/common/cards/CardLg.vue';
 import CardSm from '@/components/common/cards/CardSm.vue';
 import Section from '@/components/common/Section.vue';
 import Modal from '@/components/common/Modal.vue';
+import ProgressBar from '@/components/common/ProgressBar.vue';
 import { useNotificationStore } from '@/stores/notification';
 
 const notificationStore = useNotificationStore();

--- a/src/views/docs/DocsView.vue
+++ b/src/views/docs/DocsView.vue
@@ -62,7 +62,7 @@
       <DocsListView v-if="viewMode === 'list'" />
     </div>
 
-    <!-- ✅ 공통 서류 추가 모달 -->
+    <!-- 공통 서류 추가 모달 -->
     <Modal
       :show="showUploadModal"
       title="서류 추가"

--- a/src/views/docs/DocsView.vue
+++ b/src/views/docs/DocsView.vue
@@ -7,11 +7,7 @@
     />
 
     <!-- 서류 패널 -->
-    <DocsHelperPanel
-      :show-upload-modal="showUploadModal"
-      @close-upload-modal="showUploadModal = false"
-      @add-document="handleAddDocument"
-    />
+    <DocsHelperPanel @show-upload-modal="showUploadModal = true" />
 
     <!-- 메인 컨텐츠 -->
     <div class="px-6 pb-6">
@@ -65,6 +61,55 @@
       <!-- 리스트 뷰 -->
       <DocsListView v-if="viewMode === 'list'" />
     </div>
+
+    <!-- ✅ 공통 서류 추가 모달 -->
+    <Modal
+      :show="showUploadModal"
+      title="서류 추가"
+      cancel-text="취소"
+      confirm-text="추가"
+      @close="closeUploadModal"
+      @cancel="closeUploadModal"
+      @confirm="handleAddDocument"
+    >
+      <div class="space-y-4">
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >서류명</label
+          >
+          <input
+            v-model="newDoc.name"
+            type="text"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+          />
+        </div>
+
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >발급일</label
+          >
+          <input
+            v-model="newDoc.issueDate"
+            type="date"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+          />
+        </div>
+
+        <div>
+          <label class="mb-2 block text-sm font-medium text-gray-700"
+            >서류 파일</label
+          >
+          <input
+            type="file"
+            required
+            class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-[#2563EB]"
+            @change="handleFileUpload"
+          />
+        </div>
+      </div>
+    </Modal>
   </div>
 </template>
 
@@ -76,9 +121,17 @@ import DocsHelperPanel from '@/components/docs/DocsHelperPanel.vue';
 import KanbanBoard from '@/components/docs/KanbanBoard.vue';
 import DocsListView from '@/components/docs/DocsListView.vue';
 import Dropdown from '@/components/common/Dropdown.vue';
+import Modal from '@/components/common/Modal.vue';
 
 const docsStore = useDocsStore();
 const showUploadModal = ref(false);
+
+// 새로운 서류 데이터
+const newDoc = ref({
+  name: '',
+  issueDate: '',
+  file: null,
+});
 
 const viewMode = computed(() => docsStore.viewMode);
 
@@ -88,13 +141,13 @@ const filters = ref({ ...docsStore.filters });
 
 // 드롭다운 옵션들
 const typeOptions = [
-  { value: 'all', label: '전체' },
+  { value: 'all', label: '정책/대출' },
   { value: 'policy', label: '정책' },
   { value: 'loan', label: '대출' },
 ];
 
 const statusOptions = [
-  { value: 'all', label: '전체' },
+  { value: 'all', label: '상태' },
   { value: 'requirements', label: '요건확인' },
   { value: 'collecting', label: '수집중' },
   { value: 'preparing', label: '제출준비' },
@@ -115,77 +168,60 @@ watch(
   { deep: true }
 );
 
-const handleAddDocument = documentData => {
-  console.log('새 서류 추가:', documentData);
+const handleFileUpload = event => {
+  newDoc.value.file = event.target.files[0];
+};
+
+const handleAddDocument = () => {
+  if (!newDoc.value.name || !newDoc.value.issueDate || !newDoc.value.file)
+    return;
+
+  console.log('새 서류 추가:', newDoc.value);
+
+  // TODO: 실제 store에 저장하는 로직 추가 가능
+  docsStore.addDocument?.(newDoc.value);
+
+  // 초기화 & 닫기
+  newDoc.value = { name: '', issueDate: '', file: null };
+  showUploadModal.value = false;
+};
+
+const closeUploadModal = () => {
+  showUploadModal.value = false;
+  newDoc.value = { name: '', issueDate: '', file: null };
 };
 
 // ZIP 다운로드 처리
 const handleDownloadZip = async () => {
   try {
-    // 현재 사용자의 서류 목록 가져오기 (필터링된 결과)
     const userDocuments = docsStore.filteredItems;
-
     if (userDocuments.length === 0) {
       alert('다운로드할 서류가 없습니다.');
       return;
     }
 
-    // JSZip 라이브러리 사용하여 ZIP 생성
     const JSZip = await import('jszip');
     const zip = new JSZip.default();
 
-    // 각 서류에 대한 가상 파일 생성
-    userDocuments.forEach((doc, index) => {
-      // 서류 정보를 텍스트 파일로 생성
+    userDocuments.forEach(doc => {
       const docInfo = `서류명: ${doc.name}
 기관: ${doc.institution}
 타입: ${doc.type}
 상태: ${doc.status}
 진행률: ${doc.progress}%
 완료된 서류: ${doc.completedDocs}/${doc.totalDocs}
-마감일: ${doc.deadline}
-
-첨부된 파일 목록:
-${doc.files ? doc.files.map(file => `- ${file.name} (${file.size})`).join('\n') : '첨부된 파일 없음'}
-
-생성일: ${new Date().toLocaleDateString('ko-KR')}`;
-
-      // 파일명 생성 (특수문자 제거)
+마감일: ${doc.deadline}`;
       const fileName = `${doc.name.replace(/[^a-zA-Z0-9가-힣]/g, '_')}_${doc.institution.replace(/[^a-zA-Z0-9가-힣]/g, '_')}.txt`;
-
       zip.file(fileName, docInfo);
-
-      // 첨부된 파일들도 가상으로 생성 (실제 파일이 아닌 더미 파일)
-      if (doc.files && doc.files.length > 0) {
-        doc.files.forEach(file => {
-          const fileContent = `이 파일은 ${file.name}의 가상 복사본입니다.
-원본 파일 크기: ${file.size}
-파일 타입: ${file.type}
-서류명: ${doc.name}
-기관: ${doc.institution}
-생성일: ${new Date().toLocaleDateString('ko-KR')}`;
-
-          zip.file(
-            `${doc.name.replace(/[^a-zA-Z0-9가-힣]/g, '_')}/${file.name}`,
-            fileContent
-          );
-        });
-      }
     });
 
-    // 전체 서류 요약 정보 생성
     const summaryInfo = `서류 다운로드 요약
 ====================
 다운로드 일시: ${new Date().toLocaleString('ko-KR')}
-총 서류 수: ${userDocuments.length}개
-총 파일 수: ${userDocuments.reduce((total, doc) => total + (doc.files ? doc.files.length : 0), 0)}개
-
-서류 목록:
-${userDocuments.map((doc, index) => `${index + 1}. ${doc.name} (${doc.institution}) - ${doc.status}`).join('\n')}`;
+총 서류 수: ${userDocuments.length}개`;
 
     zip.file('서류_요약.txt', summaryInfo);
 
-    // ZIP 파일 생성 및 다운로드
     const zipBlob = await zip.generateAsync({ type: 'blob' });
     const url = URL.createObjectURL(zipBlob);
     const link = document.createElement('a');


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #35 

## ✨️ 작업 내용
<!-- 작업 내용을 간략히 설명해주세요 -->
- 상품에 필요한 서류 : 워딩 변경 (즐겨찾기~~), 툴팁 추가 (즐겨찾기한 상품 안내)

- 즐겨찾기 수정할 수 있는 방안 (최소 http://localhost:5173/schedule/favorites로 라우팅)
- 요구 건수 : 워딩 변경 (해당 서류), 숫자 클릭 시 해당하는 서류 목록 모달 veiw

- '내 보유' 상테에 '만료' 제거
- 상품 정보에 상품 신청 기간 d-day 추가
- 상품 필터 드롭다운에 default 값 '전체' 말고 직관적으로 수정
- 상품별 액션 -> 체크리스트 only : 클릭 시 해당 상품에 필요한 서류 항목 & 각각 보유 여부 체크리스트로 표시
- 칸반보드 각 단계 색상 구분
- 진행바 공통 컴포넌트로 분리

## ✔️ 체크 리스트
<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
- [X] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [X] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [X] develop에서 pull을 받은 후 conflict를 처리하고 push 했는가?
- [X] 라벨을 등록했는가?
- [X] 리뷰어를 지정했는가?

## 📸 구현 결과
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->
<img width="1920" height="1418" alt="image" src="https://github.com/user-attachments/assets/4ebf8d73-e87b-4281-a8b8-ffd644496fe0" />
<img width="1920" height="1418" alt="image" src="https://github.com/user-attachments/assets/5d1857ba-23fd-43f7-8a5f-ed357742d975" />
<img width="1920" height="1418" alt="image" src="https://github.com/user-attachments/assets/e825ea04-1222-4fc5-862e-49d67eda84bd" />
<img width="1920" height="1418" alt="image" src="https://github.com/user-attachments/assets/9a96d714-3d8d-49d5-9fa1-f9801b21db9e" />

## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
