### PR TITLE
[Feat] #38 : 마이페이지(header) 드롭다운 UI

### DIFF
--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -78,7 +78,7 @@
             :user-info="userInfo"
             :avatar="avatar"
             @mypage="goMyPage"
-            @logout-click="$emit('logout')"
+            @logout-click="handleLogout"
           />
         </div>
       </div>
@@ -105,7 +105,8 @@ defineProps({
   avatar: { type: String, default: '' }, // 프로필 이미지 URL(없으면 아이콘)
 });
 
-defineEmits(['logout']); // 부모에서 로그아웃 처리(모달 등)
+const emit = defineEmits(['logout']);
+const handleLogout = () => emit('logout');
 
 const router = useRouter();
 const goMyPage = () => {

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -1,11 +1,6 @@
+<!-- src/components/common/AppHeader.vue -->
 <template>
-  <header
-    :class="
-      overlay
-        ? 'absolute inset-x-0 top-0 z-40 border-b-0 bg-transparent'
-        : 'sticky top-0 z-40 border-b border-gray-200 bg-white'
-    "
-  >
+  <header class="sticky top-0 z-50 border-b border-gray-200 bg-white">
     <div class="mx-auto max-w-7xl px-4">
       <div class="flex h-16 items-center justify-between">
         <!-- 로고 -->
@@ -25,6 +20,11 @@
         <nav class="hidden items-center space-x-8 md:flex" aria-label="Primary">
           <slot name="nav">
             <a
+              href="/onboarding"
+              class="cursor-pointer font-medium text-gray-700 hover:text-primary"
+              >전체 상품</a
+            >
+            <a
               href="/schedule"
               class="cursor-pointer font-medium text-gray-700 hover:text-primary"
               >일정</a
@@ -37,24 +37,19 @@
             <a
               href="/report"
               class="cursor-pointer font-medium text-gray-700 hover:text-primary"
+              >리포트</a
             >
-              리포트
-            </a>
             <a
               href="/community"
               class="cursor-pointer font-medium text-gray-700 hover:text-primary"
               >커뮤니티</a
-            >
-            <a
-              href="/test"
-              class="cursor-pointer font-medium text-gray-700 hover:text-primary"
-              >컴포넌트 테스트</a
             >
           </slot>
         </nav>
 
         <!-- 칩/알림/프로필 -->
         <div class="flex items-center space-x-4">
+          <!-- 칩 -->
           <div
             v-if="chips && chips.length"
             class="hidden items-center space-x-2 sm:flex"
@@ -63,47 +58,28 @@
               v-for="chip in chips"
               :key="chip"
               class="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"
-              >{{ chip }}</span
             >
+              {{ chip }}
+            </span>
           </div>
 
-          <!-- 알림 아이콘 -->
-          <div class="relative inline-block">
-            <button
-              v-if="showBell"
-              class="relative rounded-full p-2 hover:bg-gray-100"
-              aria-label="알림"
-              @click="toggleNotifications"
-            >
-              <i
-                class="fas fa-bell text-lg text-gray-600"
-                aria-hidden="true"
-              ></i>
-              <!-- 읽지 않은 알림 개수 표시 -->
-              <span
-                v-if="unreadCount > 0"
-                class="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white"
-              >
-                {{ unreadCount > 9 ? '9+' : unreadCount }}
-              </span>
-            </button>
-
-            <!-- 알림 드롭다운 -->
-            <NotificationDropdown
-              :is-open="isNotificationsOpen"
-              @close="closeNotifications"
-            />
-          </div>
-
-          <RouterLink
-            to="/mypage"
-            class="flex h-8 w-8 items-center justify-center rounded-full bg-primary"
-            aria-label="프로필"
+          <!-- 알림 -->
+          <button
+            v-if="showBell"
+            class="rounded-full p-2 hover:bg-gray-100"
+            aria-label="알림"
           >
-            <slot name="avatar">
-              <i class="fas fa-user text-sm text-white" aria-hidden="true"></i>
-            </slot>
-          </RouterLink>
+            <i class="fas fa-bell text-lg text-gray-600" aria-hidden="true"></i>
+          </button>
+
+          <!-- 프로필: 아바타 클릭 시 드롭다운 -->
+          <!-- RouterLink 대신 ProfileDropdown 사용 -->
+          <ProfileDropdown
+            :user-info="userInfo"
+            :avatar="avatar"
+            @mypage="goMyPage"
+            @logout-click="$emit('logout')"
+          />
         </div>
       </div>
     </div>
@@ -111,27 +87,28 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
-import { storeToRefs } from 'pinia';
-import { useNotificationStore } from '@/stores/notification';
-import NotificationDropdown from './NotificationDropdown.vue';
+import { useRouter } from 'vue-router';
+import ProfileDropdown from '../mypage/ProfileDropdown.vue';
 
-const props = defineProps({
-  chips: { type: Array, default: () => [] },
-  showBell: { type: Boolean, default: true },
-  overlay: { type: Boolean, default: false },
+defineProps({
+  chips: { type: Array, default: () => [] }, // 우측 칩(태그) 리스트
+  showBell: { type: Boolean, default: true }, // 알림 버튼 보이기
+  userInfo: {
+    // 드롭다운 상단 표시 정보
+    type: Object,
+    default: () => ({
+      name: '사용자',
+      region: '서울',
+      business: '카페/디저트',
+    }),
+  },
+  avatar: { type: String, default: '' }, // 프로필 이미지 URL(없으면 아이콘)
 });
 
-const notificationStore = useNotificationStore();
-const { unreadCount } = storeToRefs(notificationStore);
+defineEmits(['logout']); // 부모에서 로그아웃 처리(모달 등)
 
-const isNotificationsOpen = ref(false);
-
-const toggleNotifications = () => {
-  isNotificationsOpen.value = !isNotificationsOpen.value;
-};
-
-const closeNotifications = () => {
-  isNotificationsOpen.value = false;
+const router = useRouter();
+const goMyPage = () => {
+  router.push('/mypage');
 };
 </script>

--- a/src/components/mypage/ProfileDropdown.vue
+++ b/src/components/mypage/ProfileDropdown.vue
@@ -1,0 +1,100 @@
+<template>
+  <div ref="rootEl" class="relative">
+    <!-- 트리거 버튼 -->
+    <button
+      class="!rounded-button flex cursor-pointer items-center space-x-2 rounded-full p-2 transition-colors hover:bg-gray-100"
+      aria-haspopup="menu"
+      :aria-expanded="open ? 'true' : 'false'"
+      @click="toggle"
+    >
+      <div
+        class="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-primary"
+      >
+        <template v-if="avatar">
+          <img :src="avatar" alt="avatar" class="h-full w-full object-cover" />
+        </template>
+        <i v-else class="fas fa-user text-sm text-white"></i>
+      </div>
+    </button>
+
+    <!-- 드롭다운 -->
+    <div
+      v-show="open"
+      class="absolute right-0 z-50 mt-2 w-64 rounded-xl border border-gray-200 bg-white py-2 shadow-lg"
+      role="menu"
+      @keydown.esc="open = false"
+    >
+      <!-- 사용자 정보 -->
+      <div class="border-b border-gray-100 px-4 py-3">
+        <p class="truncate text-base font-bold text-gray-900">
+          {{ userInfo.name }}
+        </p>
+        <p class="mt-1 truncate text-sm text-gray-500">
+          <span v-if="userInfo.region">{{ userInfo.region }}</span>
+          <span v-if="userInfo.region && userInfo.business"> · </span>
+          <span v-if="userInfo.business">{{ userInfo.business }}</span>
+        </p>
+      </div>
+
+      <!-- 메뉴 -->
+      <div class="py-1">
+        <button
+          class="w-full cursor-pointer whitespace-nowrap px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-50"
+          role="menuitem"
+          @click="goMyPage"
+        >
+          <i class="fas fa-user-circle mr-2"></i>마이페이지
+        </button>
+        <button
+          class="w-full cursor-pointer whitespace-nowrap px-4 py-2 text-left text-sm text-red-600 transition-colors hover:bg-red-50"
+          role="menuitem"
+          @click="logoutClick"
+        >
+          <i class="fas fa-sign-out-alt mr-2"></i>로그아웃
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+/* ✅ TS 타입 제거하고 런타임 props로 전환 (ESLint 파싱 에러 해결) */
+defineProps({
+  userInfo: { type: Object, required: true },
+  avatar: { type: String, default: '' },
+});
+
+const emit = defineEmits(['mypage', 'logout-click']);
+
+const open = ref(false);
+const rootEl = ref(null);
+
+const toggle = () => (open.value = !open.value);
+const close = () => (open.value = false);
+
+const onDocClick = e => {
+  const t = e.target;
+  if (rootEl.value && !rootEl.value.contains(t)) close();
+};
+
+const goMyPage = () => {
+  emit('mypage');
+  close();
+};
+
+const logoutClick = () => {
+  emit('logout-click');
+  close();
+};
+
+onMounted(() => document.addEventListener('click', onDocClick));
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick));
+</script>
+
+<style scoped>
+.\!rounded-button {
+  border-radius: 8px;
+}
+</style>


### PR DESCRIPTION
## 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #38

## ✨️ 작업 내용
<!-- 작업 내용을 간략히 설명해주세요 -->
 마이페이지(header) 드롭다운 UI를 만들었습니다. 

여기서 마이페이지 라우터와 로그아웃을 할 수 있습니다. 

## ✔️ 체크 리스트
<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] develop에서 pull을 받은 후 conflict를 처리하고 push 했는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📸 구현 결과
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->
<img width="1162" height="264" alt="스크린샷 2025-09-03 오후 2 25 32" src="https://github.com/user-attachments/assets/4dc33eae-400c-4763-8243-ec8d666e8fe4" />


## 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
